### PR TITLE
update voting power and weight

### DIFF
--- a/whitepaper.md
+++ b/whitepaper.md
@@ -255,7 +255,9 @@ The goal of building a community currency is to get more “crabs in the bucket�
 
 A major part of minimizing abuse is the rate-limiting of voting. Individual users can only read and evaluate so many work items per day. Any attempt to vote more frequently than this is a sign of automation and potential abuse. Through rate limiting, stakeholders who vote more frequently have each vote count for less than stakeholders who vote less frequently. Attempts to divide tokens among multiple accounts also divides influence and therefore does not result in a net increase in influence nor bypass the rate-limit imposed on voting.
 
-Users are allotted a fixed amount of voting power. Voting power is multiplied by a user’s vesting tokens to determine how much share in the reward pool should be allocated to a given work item. Every vote that is cast uses a percentage of remaining voting power, from 0% to maximum 2% whose value is defined by the user through a weight. Users can vote for more posts, but each vote will be worth less, and it will take longer to reach full voting power again. Voting power recharges at a fixed linear rate of 20% per day. 
+Users are allotted a fixed amount of voting power. Voting power is multiplied by a user’s vesting tokens to determine how much share in the reward pool should be allocated to a given work item. Every vote that is cast uses a percentage of remaining voting power. Users can vote for more posts, but each vote will be worth less, and it will take longer to reach full voting power again. Voting power recharges at a fixed linear rate of 20% per day.
+
+Users can define a strength for each vote (0% - 100%). A strength of 100% represents 2% of the remaining voting power, and this is the used power to compute the shares as mentioned above. This is useful so that users with a large amount of Steem Power can better manage their voting power.
 
 ### Payout Distribution
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -255,7 +255,7 @@ The goal of building a community currency is to get more “crabs in the bucket�
 
 A major part of minimizing abuse is the rate-limiting of voting. Individual users can only read and evaluate so many work items per day. Any attempt to vote more frequently than this is a sign of automation and potential abuse. Through rate limiting, stakeholders who vote more frequently have each vote count for less than stakeholders who vote less frequently. Attempts to divide tokens among multiple accounts also divides influence and therefore does not result in a net increase in influence nor bypass the rate-limit imposed on voting.
 
-Users are allotted a fixed amount of voting power. Voting power is multiplied by a user’s vesting tokens to determine how much share in the reward pool should be allocated to a given work item. Every vote that is cast uses a percentage of remaining voting power. Users can vote for more posts, but each vote will be worth less, and it will take longer to reach full voting power again. Voting power recharges at a fixed linear rate of 20% per day. 
+Users are allotted a fixed amount of voting power. Voting power is multiplied by a user’s vesting tokens to determine how much share in the reward pool should be allocated to a given work item. Every vote that is cast uses a percentage of remaining voting power, from 0% to maximum 2% whose value is defined by the user through a weight. Users can vote for more posts, but each vote will be worth less, and it will take longer to reach full voting power again. Voting power recharges at a fixed linear rate of 20% per day. 
 
 ### Payout Distribution
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -257,7 +257,7 @@ A major part of minimizing abuse is the rate-limiting of voting. Individual user
 
 Users are allotted a fixed amount of voting power. Voting power is multiplied by a user’s vesting tokens to determine how much share in the reward pool should be allocated to a given work item. Every vote that is cast uses a percentage of remaining voting power. Users can vote for more posts, but each vote will be worth less, and it will take longer to reach full voting power again. Voting power recharges at a fixed linear rate of 20% per day.
 
-Users can define a strength for each vote (0% - 100%). A strength of 100% represents 2% of the remaining voting power, and this is the used power to compute the shares as mentioned above. This is useful so that users with a large amount of Steem Power can better manage their voting power.
+Users can define a strength for each vote. The minimum possible strength is the voting power percentage that allocates 50 VESTS to the pool. And the maximum strength is 2% of the remaining voting power. This is useful so that users with a large amount of Steem Power can better manage their voting power.
 
 ### Payout Distribution
 


### PR DESCRIPTION
TL;DR the power used goes from 0% to 2% of the remaining voting power approx.

In the source code [evaluator.cpp](https://github.com/steemit/steem/blob/5a7220e47e6a49b6df85c0c4f994a1a644061c9c/libraries/chain/steem_evaluator.cpp):
```
used_power  = ((current_power * abs_weight) / STEEM_100_PERCENT) * (60*60*24);
max_vote_denom = dgpo.vote_power_reserve_rate * STEEM_VOTE_REGENERATION_SECONDS;
used_power = (used_power + max_vote_denom - 1) / max_vote_denom;
abs_rshares = voter.effective_vesting_shares().amount.value * used_power / STEEM_100_PERCENT
```

In conclusion, and replacing the constants:
```abs_rshares = vesting_shares * ((current_power * abs_weight)/10000 + 50 - 1/(60*60*24)) / (50*10000)```
then, it is approx.
```abs_rshares = vesting_shares * current_power/(50*10000) * abs_weight/10000```

Then the maximum power used is 1/50 of the current power approx. That is, 2%.